### PR TITLE
fix: point Pi at a top-level extension entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ If you are editing this repo locally, the symlink workflow is still useful:
 
 | Method | When to use |
 |---|---|
-| `ln -s "$PWD/src/index.ts" ~/.pi/agent/extensions/pi-hooks.ts` | Local development with a checked-out repo. |
-| `pi -e /path/to/pi-hooks/src/index.ts` | One-off local testing from a checkout. |
+| `ln -s "$PWD/extensions/index.ts" ~/.pi/agent/extensions/pi-hooks.ts` | Local development with a checked-out repo. |
+| `pi -e /path/to/pi-hooks/extensions/index.ts` | One-off local testing from a checkout. |
 | `<project>/.pi/extensions/pi-hooks.ts` | Project-local local-dev install from a checkout. |
 
 ## Quick start

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -60,7 +60,7 @@ Project settings override global ones, and PI installs missing project packages 
 | Method | Use when |
 |---|---|
 | `pi -e git:git@github.com:KristjanPikhof/pi-yaml-hooks` | You want a one-off run without writing settings |
-| `ln -s "$PWD/src/index.ts" ~/.pi/agent/extensions/pi-hooks.ts` | You are editing a local checkout and want PI to load that working tree |
+| `ln -s "$PWD/extensions/index.ts" ~/.pi/agent/extensions/pi-hooks.ts` | You are editing a local checkout and want PI to load that working tree |
 | `<project>/.pi/extensions/pi-hooks.ts` | You want a project-local local-dev install from a checkout |
 
 ## Create your first hook file

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,0 +1,1 @@
+export { default } from "../src/index.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hooks",
-  "version": "2026-04-22",
+  "version": "2026-04-23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hooks",
-      "version": "2026-04-22",
+      "version": "2026-04-23",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
   },
   "pi": {
     "extensions": [
-      "./src/index.ts"
+      "./extensions/index.ts"
     ]
   },
   "keywords": [
     "pi-package"
   ],
   "files": [
+    "extensions",
     "src",
     "docs",
     "examples",


### PR DESCRIPTION
## Summary
Point Pi at a top-level extension entrypoint so the package loads through `extensions/index.ts` instead of `src/index.ts`. This keeps the package-facing structure consistent with `pi-agent-team` while preserving the existing implementation layout under `src/`.

## Changes
- add `extensions/index.ts` as a thin re-export of `src/index.ts`
- update `package.json` so the Pi manifest points at `./extensions/index.ts`
- include `extensions/` in published package files
- update local development docs to reference the new entrypoint