### PR TITLE
Add post-tool path filters and developer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ or use the built-in command:
 
 ## Examples
 
-Example workflows live under [`examples/`](./examples/). The main one today is [`examples/atomic-commit-snapshot-worker/`](./examples/atomic-commit-snapshot-worker/).
+Example workflows live under [`examples/`](./examples/). Start with [`examples/README.md`](./examples/README.md) for complete example packs, including pre-tool developer guards and post-tool developer feedback hooks.
 
-That snapshot worker is an opt-in example, not a built-in PI feature.
+These packs are opt-in examples, not built-in PI features.
 
 ## Docs
 

--- a/docs/agent-authoring-guide.md
+++ b/docs/agent-authoring-guide.md
@@ -76,6 +76,8 @@ Why:
 - it works across recognized mutation tools
 - it keeps path-based logic in one place
 
+Use path conditions on `tool.after.<name>` when you deliberately want tool-specific post-processing, such as reacting only to `tool.after.write` events under `src/**`. The condition still needs changed paths; non-mutating tools such as `read`, `grep`, `find`, and `ls` will not match path filters.
+
 ### Use `session.idle` for batching
 
 If you want one action after a burst of edits, prefer `session.idle`.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -16,6 +16,12 @@ These examples are designed to be copied into `hooks.yaml` with minimal editing.
 - [`tail-hook-logs.md`](./tail-hook-logs.md) — tail and filter the persistent hook log while debugging
 - [`snapshot-autocommit.md`](./snapshot-autocommit.md) — hook up the included Python snapshot worker example
 
+## Complete example packs
+
+- [`../../examples/pre-tool-developer-guards/`](../../examples/pre-tool-developer-guards/) — pre-tool guards for risky bash, protected files, and dependency installs
+- [`../../examples/post-tool-developer-feedback/`](../../examples/post-tool-developer-feedback/) — post-tool logging, status, and follow-up prompts for developer workflows
+- [`../../examples/atomic-commit-snapshot-worker/`](../../examples/atomic-commit-snapshot-worker/) — advanced snapshot worker example
+
 ## Before you paste
 
 - If you are using a project hook file, trust the project first.

--- a/docs/examples/path-filters.md
+++ b/docs/examples/path-filters.md
@@ -18,6 +18,22 @@ hooks:
 
 This runs if at least one changed path matches one of the patterns.
 
+## Filter a specific post-tool event by path
+
+```yaml
+hooks:
+  - id: write-src-ts-change
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "src/**/*.ts"
+          - "src/**/*.tsx"
+    actions:
+      - notify: "A TypeScript source file was written"
+```
+
+This runs only after the `write` tool and only when the written path matches one of the patterns. Use `file.changed` instead when the workflow should react to the path regardless of whether `write`, `edit`, or a recognized mutation-shaped `bash` command caused it.
+
 ## Run only when all changed paths stay inside one area
 
 ```yaml

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -151,6 +151,15 @@ Practical note:
 - it is most useful on `file.changed`, `tool.after.<mutation>`, and `session.idle`
 - on events with no file context, it will not match
 
+Path conditions are accepted on these events:
+
+- `file.changed`
+- `session.idle`
+- `tool.after.*`
+- `tool.after.<name>`
+
+For `tool.after.*` and `tool.after.<name>`, they only match when `pi-hooks` can infer changed paths from the tool result. Stock PI path context is available for `write`, `edit`, and recognized mutation-shaped `bash` commands. Non-mutating tools such as `read`, `grep`, `find`, and `ls` have no changed paths, so path conditions on those events do not match.
+
 ### `matchesAnyPath`
 
 ```yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+# Example hook packs
+
+These folders are complete example packs. Copy the `hooks.yaml` snippets into a global or trusted project hook file, and keep any referenced scripts at the paths used by the YAML or update those paths.
+
+## Packs
+
+- [`pre-tool-developer-guards`](./pre-tool-developer-guards/) — block risky shell commands and protected-file edits before tools run
+- [`post-tool-developer-feedback`](./post-tool-developer-feedback/) — log useful post-tool context, update status, and nudge follow-up checks after developer-facing changes
+- [`atomic-commit-snapshot-worker`](./atomic-commit-snapshot-worker/) — advanced opt-in snapshot worker example
+
+These are examples only. They are not built-in `pi-hooks` product features.

--- a/examples/post-tool-developer-feedback/README.md
+++ b/examples/post-tool-developer-feedback/README.md
@@ -1,0 +1,39 @@
+# Post-tool developer feedback
+
+Use this pack when you want lightweight feedback after tools mutate code or project metadata.
+
+## Good use cases
+
+| Hook | Use it when |
+|---|---|
+| `log-source-write` | You want a small audit trail for source files written by PI. |
+| `log-source-edit` | You want the same audit trail for edits. |
+| `mark-package-change` | You want the UI to show that dependency metadata changed. |
+| `suggest-package-check` | You want the current PI session nudged to consider validation after package files change. |
+
+## Install
+
+Copy `hooks.yaml` into your global hook file or a trusted project hook file.
+
+If you keep the script in this repository, run PI from the repository root or update this path in `hooks.yaml`:
+
+```yaml
+bash: 'node ./examples/post-tool-developer-feedback/post-tool-log.mjs'
+```
+
+For another project, copy `post-tool-log.mjs` into that project and point the YAML at the copied path.
+
+## Behavior
+
+- `tool.after.write` and `tool.after.edit` hooks use path conditions, so they only run for selected paths.
+- The logger appends NDJSON to `.pi-hook-logs/tool-events.ndjson`.
+- `setStatus` updates PI UI status when a UI surface exists.
+- `tool:` sends a follow-up prompt into the current PI session; it does not imperatively run the tool.
+
+## Quick test
+
+1. Add the hooks.
+2. Ask PI to edit or write a file under `src/`.
+3. Check `.pi-hook-logs/tool-events.ndjson`.
+4. Ask PI to modify `package.json`.
+5. Confirm the status entry updates and the session receives the follow-up prompt.

--- a/examples/post-tool-developer-feedback/hooks.yaml
+++ b/examples/post-tool-developer-feedback/hooks.yaml
@@ -1,0 +1,47 @@
+hooks:
+  - id: log-source-write
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "src/**"
+          - "test/**"
+          - "tests/**"
+    actions:
+      - bash: 'node ./examples/post-tool-developer-feedback/post-tool-log.mjs'
+
+  - id: log-source-edit
+    event: tool.after.edit
+    conditions:
+      - matchesAnyPath:
+          - "src/**"
+          - "test/**"
+          - "tests/**"
+    actions:
+      - bash: 'node ./examples/post-tool-developer-feedback/post-tool-log.mjs'
+
+  - id: mark-package-change
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "package.json"
+          - "package-lock.json"
+          - "pnpm-lock.yaml"
+          - "yarn.lock"
+          - "bun.lock"
+    actions:
+      - setStatus: "Dependency metadata changed"
+
+  - id: suggest-package-check
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "package.json"
+          - "package-lock.json"
+          - "pnpm-lock.yaml"
+          - "yarn.lock"
+          - "bun.lock"
+    actions:
+      - tool:
+          name: bash
+          args:
+            command: "npm test"

--- a/examples/post-tool-developer-feedback/post-tool-log.mjs
+++ b/examples/post-tool-developer-feedback/post-tool-log.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { mkdir, appendFile } from "node:fs/promises"
+import path from "node:path"
+
+const payload = JSON.parse(await readStdin())
+const cwd = typeof payload.cwd === "string" ? payload.cwd : process.cwd()
+const logDir = path.join(cwd, ".pi-hook-logs")
+const logPath = path.join(logDir, "tool-events.ndjson")
+
+const entry = {
+  timestamp: new Date().toISOString(),
+  event: payload.event,
+  tool: payload.tool_name,
+  files: Array.isArray(payload.files) ? payload.files : [],
+  changes: Array.isArray(payload.changes) ? payload.changes : [],
+}
+
+await mkdir(logDir, { recursive: true })
+await appendFile(logPath, `${JSON.stringify(entry)}\n`, "utf8")
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+}

--- a/examples/pre-tool-developer-guards/README.md
+++ b/examples/pre-tool-developer-guards/README.md
@@ -1,0 +1,38 @@
+# Pre-tool developer guards
+
+Use this pack when you want fast checks before PI runs tools that can mutate a project.
+
+## Good use cases
+
+| Hook | Use it when |
+|---|---|
+| `guard-risky-bash` | You want to block obviously dangerous shell commands before they run. |
+| `guard-protected-write` | You want to stop direct writes to secrets, certificates, keys, and local environment files. |
+| `guard-package-install` | You want package installs and dependency updates to be explicit human actions. |
+
+## Install
+
+Copy `hooks.yaml` into your global hook file or a trusted project hook file.
+
+If you keep the script in this repository, run PI from the repository root or update this path in `hooks.yaml`:
+
+```yaml
+bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+```
+
+For another project, copy `pre-tool-policy.mjs` into that project and point the YAML at the copied path.
+
+## Behavior
+
+- Exit code `2` blocks the matching pre-tool call.
+- These hooks inspect the tool payload before execution; they do not run on `tool.after.*`.
+
+## Quick test
+
+1. Add the hooks.
+2. Ask PI to run `git reset --hard`.
+3. Confirm the bash tool call is blocked.
+4. Ask PI to write `.env`.
+5. Confirm the write tool call is blocked.
+6. Ask PI to run a harmless command like `pwd`.
+7. Confirm it still runs.

--- a/examples/pre-tool-developer-guards/README.md
+++ b/examples/pre-tool-developer-guards/README.md
@@ -8,6 +8,7 @@ Use this pack when you want fast checks before PI runs tools that can mutate a p
 |---|---|
 | `guard-risky-bash` | You want to block obviously dangerous shell commands before they run. |
 | `guard-protected-write` | You want to stop direct writes to secrets, certificates, keys, and local environment files. |
+| `guard-protected-edit` | You want the same protection for edit-based file changes. |
 | `guard-package-install` | You want package installs and dependency updates to be explicit human actions. |
 
 ## Install
@@ -34,5 +35,7 @@ For another project, copy `pre-tool-policy.mjs` into that project and point the 
 3. Confirm the bash tool call is blocked.
 4. Ask PI to write `.env`.
 5. Confirm the write tool call is blocked.
-6. Ask PI to run a harmless command like `pwd`.
-7. Confirm it still runs.
+6. Ask PI to run `npm install left-pad`.
+7. Confirm the package install is blocked.
+8. Ask PI to run a harmless command like `pwd`.
+9. Confirm it still runs.

--- a/examples/pre-tool-developer-guards/hooks.yaml
+++ b/examples/pre-tool-developer-guards/hooks.yaml
@@ -1,0 +1,20 @@
+hooks:
+  - id: guard-risky-bash
+    event: tool.before.bash
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-protected-write
+    event: tool.before.write
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-protected-edit
+    event: tool.before.edit
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs'
+
+  - id: guard-package-install
+    event: tool.before.bash
+    actions:
+      - bash: 'node ./examples/pre-tool-developer-guards/pre-tool-policy.mjs --package-install-only'

--- a/examples/pre-tool-developer-guards/pre-tool-policy.mjs
+++ b/examples/pre-tool-developer-guards/pre-tool-policy.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const payload = JSON.parse(await readStdin())
+const packageInstallOnly = process.argv.includes("--package-install-only")
+const toolName = String(payload.tool_name ?? "")
+const toolArgs = isRecord(payload.tool_args) ? payload.tool_args : {}
+
+if (toolName === "bash") {
+  const command = String(toolArgs.command ?? "")
+  const reason = packageInstallOnly ? getPackageInstallReason(command) : getRiskyCommandReason(command)
+  if (reason) {
+    block(reason)
+  }
+}
+
+if (toolName === "write" || toolName === "edit") {
+  const filePath = String(toolArgs.path ?? toolArgs.filePath ?? toolArgs.file_path ?? toolArgs.file ?? "")
+  if (isProtectedPath(filePath)) {
+    block(`Blocked ${toolName} to protected path: ${filePath}`)
+  }
+}
+
+function getRiskyCommandReason(command) {
+  const compact = command.replace(/\s+/g, " ").trim()
+  const rules = [
+    [/(\s|^)git\s+reset\s+--hard(\s|$)/, "Blocked git reset --hard"],
+    [/(\s|^)git\s+clean\s+-[^\n;]*f[^\n;]*d/, "Blocked destructive git clean"],
+    [/(\s|^)rm\s+-[^\n;]*r[^\n;]*f\s+(\/|\$HOME|~)(\s|$)/, "Blocked broad rm -rf target"],
+    [/(\s|^)chmod\s+-R\s+777(\s|$)/, "Blocked recursive chmod 777"],
+    [/(curl|wget)[^|;&]*\|\s*(sh|bash)(\s|$)/, "Blocked pipe-to-shell install command"],
+  ]
+
+  return rules.find(([pattern]) => pattern.test(compact))?.[1]
+}
+
+function getPackageInstallReason(command) {
+  const compact = command.replace(/\s+/g, " ").trim()
+  const rules = [
+    [/(\s|^)(npm|pnpm|yarn)\s+(install|add|update|upgrade)(\s|$)/, "Blocked package install/update command"],
+    [/(\s|^)bun\s+(install|add|update)(\s|$)/, "Blocked package install/update command"],
+    [/(\s|^)pipx?\s+install(\s|$)/, "Blocked Python package install command"],
+    [/(\s|^)uv\s+(add|sync|pip\s+install)(\s|$)/, "Blocked Python dependency update command"],
+    [/(\s|^)cargo\s+(add|install|update)(\s|$)/, "Blocked Rust dependency update command"],
+    [/(\s|^)go\s+get(\s|$)/, "Blocked Go dependency update command"],
+  ]
+
+  return rules.find(([pattern]) => pattern.test(compact))?.[1]
+}
+
+function isProtectedPath(filePath) {
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "")
+  return normalized === ".env"
+    || normalized.startsWith(".env.")
+    || normalized.endsWith(".pem")
+    || normalized.endsWith(".key")
+    || normalized.endsWith(".p12")
+    || normalized.includes("/.ssh/")
+    || normalized.includes("/secrets/")
+}
+
+function block(message) {
+  console.error(message)
+  process.exit(2)
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function readStdin() {
+  const chunks = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+}

--- a/src/core/load-hooks-composition.test.ts
+++ b/src/core/load-hooks-composition.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
 
-import { loadDiscoveredHooks } from "./load-hooks.js"
+import { loadDiscoveredHooks, parseHooksFile } from "./load-hooks.js"
 
 interface Case {
   readonly name: string
@@ -219,6 +219,69 @@ const cases: Case[] = [
       } finally {
         cleanup(sandbox)
       }
+    },
+  },
+  {
+    name: "path conditions are accepted on tool.after events",
+    run: () => {
+      const result = parseHooksFile(
+        "/virtual/hooks.yaml",
+        `hooks:
+  - id: path-filtered-write
+    event: tool.after.write
+    conditions:
+      - matchesAnyPath:
+          - "src/**"
+      - matchesAllPaths: "**/*.ts"
+    actions:
+      - notify: "matched"
+`,
+      )
+
+      const hooks = result.hooks.get("tool.after.write") ?? []
+      return result.errors.length === 0 && hooks.length === 1
+        ? { ok: true }
+        : { ok: false, detail: JSON.stringify({ errors: result.errors, hooks: hooks.length }) }
+    },
+  },
+  {
+    name: "path conditions stay rejected on tool.before events",
+    run: () => {
+      const result = parseHooksFile(
+        "/virtual/hooks.yaml",
+        `hooks:
+  - id: before-path-filter
+    event: tool.before.write
+    conditions:
+      - matchesAnyPath: "src/**"
+    actions:
+      - notify: "matched"
+`,
+      )
+
+      return result.errors.some((error) => error.code === "invalid_conditions" && error.path === "hooks[0].conditions[0].matchesAnyPath")
+        ? { ok: true }
+        : { ok: false, detail: JSON.stringify(result.errors) }
+    },
+  },
+  {
+    name: "path conditions stay rejected on lifecycle events without changed paths",
+    run: () => {
+      const result = parseHooksFile(
+        "/virtual/hooks.yaml",
+        `hooks:
+  - id: created-path-filter
+    event: session.created
+    conditions:
+      - matchesAllPaths: "src/**"
+    actions:
+      - notify: "matched"
+`,
+      )
+
+      return result.errors.some((error) => error.code === "invalid_conditions" && error.path === "hooks[0].conditions[0].matchesAllPaths")
+        ? { ok: true }
+        : { ok: false, detail: JSON.stringify(result.errors) }
     },
   },
 ]

--- a/src/core/load-hooks.ts
+++ b/src/core/load-hooks.ts
@@ -876,7 +876,7 @@ function parseStructuredCondition(
       error: createError(
         filePath,
         "invalid_conditions",
-        `${conditionPath}.${key} is only supported on file.changed and session.idle hooks.`,
+        `${conditionPath}.${key} is only supported on file.changed, session.idle, and tool.after.* hooks.`,
         `${conditionPath}.${key}`,
       ),
     }
@@ -929,8 +929,8 @@ function normalizePathConditionValues(
   return { values: [...value] }
 }
 
-function supportsPathConditions(event: HookConfig["event"]): event is "file.changed" | "session.idle" {
-  return event === "file.changed" || event === "session.idle"
+function supportsPathConditions(event: HookConfig["event"]): boolean {
+  return event === "file.changed" || event === "session.idle" || event.startsWith("tool.after.")
 }
 
 function parseActions(


### PR DESCRIPTION
## Feature Description

Adds support for path conditions on `tool.after.*` hooks and documents how to use that capability in developer workflows.

## Type of Change

- [x] New feature

## Implementation Details

- Allows `matchesAnyPath` and `matchesAllPaths` on `tool.after.*` / `tool.after.<name>` hooks.
- Keeps path conditions rejected on `tool.before.*` and lifecycle events without changed-path context.
- Adds parser coverage for accepted post-tool path filters and rejected unsupported events.
- Documents when post-tool path filters are useful versus using `file.changed`.
- Adds complete example packs for pre-tool developer guards and post-tool feedback workflows.

## Key Files Changed

- `src/core/load-hooks.ts`
- `src/core/load-hooks-composition.test.ts`
- `docs/hooks-reference.md`
- `docs/examples/path-filters.md`
- `examples/pre-tool-developer-guards/`
- `examples/post-tool-developer-feedback/`

## Testing

Verified locally:

- `npm run typecheck`
- `npm run build`
- `node dist/core/load-hooks-composition.test.js`
- `node dist/core/runtime-paths.test.js`
- Parsed both new example YAML files
- Exercised the pre-tool policy script against allow/block cases
- Exercised the post-tool logger and confirmed it writes NDJSON

## Related Issues

None.
