### PR TITLE
Harden Pi 0.80 diagnostics and idle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo is the PI port of [OpenCode-Hooks](https://github.com/KristjanPikhof/O
 - Filter hooks with `matchesCodeFiles`, `matchesAnyPath`, and `matchesAllPaths`
 - Load one global root config and one trusted project root config; imports are gated by trust and opt-in env vars
 - Show built-in diagnostics with `/hooks-status`, `/hooks-validate`, `/hooks-trust`, `/hooks-reload`, and `/hooks-tail-log`
-- Emit structured in-session diagnostics when PI supports custom messages
+- Persist diagnostics as context-free custom entries on Pi 0.80-capable TUI hosts, with custom-message fallback on older or non-TUI hosts
 - Inject a short hook-awareness note before agent start (disable with `PI_YAML_HOOKS_PROMPT_AWARENESS=0`)
 
 ## Quick start
@@ -115,7 +115,7 @@ When an event matches, `pi-yaml-hooks` evaluates conditions and runs the configu
 | `tool.after.*` | After a tool call |
 | `file.changed` | Synthesized after recognized file mutations |
 | `session.created` | PI startup or a genuinely new session |
-| `session.idle` | Agent turn finished and no messages are pending |
+| `session.idle` | Agent turn has settled with no retry, compaction retry, or queued continuation remaining on capable hosts; older Pi falls back to `agent_end` behavior |
 | `session.deleted` | Best-effort cleanup on shutdown or session switch; includes PI's reason (`quit`, `reload`, `new`, `resume`, or `fork`) when available |
 
 ### Actions
@@ -138,7 +138,7 @@ When an event matches, `pi-yaml-hooks` evaluates conditions and runs the configu
 | `/hooks-reload` | Asks PI to reload extensions; edited hooks also refresh lazily on the next relevant event |
 | `/hooks-tail-log` | Log path plus a ready-to-run `tail -F` command; `--follow` starts a detached live tail, and `--path` prints only the path |
 
-`/hooks-status`, `/hooks-validate`, and hook-load validation errors also emit structured in-session diagnostics when PI supports custom messages.
+`/hooks-status`, `/hooks-validate`, and hook-load validation errors persist as custom entries on the Pi 0.80-capable TUI path. These entries do not enter model context. Older Pi and non-TUI paths retain the custom-message fallback.
 
 PI exposes `ctx.ui.addAutocompleteProvider` in the TUI editor, so `pi-yaml-hooks` layers guarded `/hooks` autocomplete only when `ctx.mode` is `"tui"` (or absent on older SDKs) and the method exists. Suggestions include the command names plus contextual hook IDs, event names, config paths, and log-tail options where useful. Hook IDs are loaded lazily and memoized by hook-snapshot signature, not fixed at extension registration time.
 

--- a/docs/debugging-hooks.md
+++ b/docs/debugging-hooks.md
@@ -10,13 +10,13 @@ Even without debug logging, hook execution failures and adapter dispatch failure
 
 ## Structured in-session diagnostics
 
-`pi-yaml-hooks` also emits structured PI-native diagnostics messages for:
+`pi-yaml-hooks` also emits structured PI-native diagnostics for:
 
 - `/hooks-status`
 - `/hooks-validate`
 - hook-load validation problems detected while loading a config
 
-These appear inline in the session when PI supports custom messages. In no-UI or other non-rendered contexts, the same message content still degrades to plain text plus the existing logs; RPC mode in Pi 0.79+ may still expose UI depending on the host.
+On the Pi 0.80-capable TUI path, these are persisted as custom entries that appear inline but do not enter model context. Older Pi and non-TUI paths retain custom messages. In no-UI or other non-rendered contexts, the same content still degrades to plain text plus the existing logs; RPC mode in Pi 0.79+ may still expose UI depending on the host.
 
 ## Log file
 

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -154,7 +154,7 @@ Custom tool names can also match if the host emits them.
 |---|---|---|
 | `file.changed` | After recognized file mutations | Synthesized by `pi-yaml-hooks`; see below for exact sources |
 | `session.created` | On PI startup or a genuinely new session | Does not fire on resume, reload, or fork re-entry |
-| `session.idle` | When the agent loop ends and there are no pending messages | Includes accumulated file changes since the last successful idle dispatch |
+| `session.idle` | When no retry, compaction retry, or queued continuation remains on capable hosts | Falls back to `agent_end` behavior on older Pi; includes accumulated file changes since the last successful idle dispatch |
 | `session.deleted` | On shutdown and before session switches | Best-effort and lossy by design; PI may provide a `reason` (`quit`, `reload`, `new`, `resume`, or `fork`), which is forwarded on the envelope when available |
 
 ### Exact `file.changed` behavior
@@ -538,7 +538,7 @@ For a real PI 0.79-compatible run, verify these compatibility-sensitive surfaces
 
 - `before_agent_start` appends the hook-awareness note when `PI_YAML_HOOKS_PROMPT_AWARENESS` is not `0`
 - no-UI/headless mode still mentions degraded UI actions in that prompt note, while RPC UI mode can deliver `notify`, `confirm`, and `setStatus` when `ctx.hasUI` is true
-- `/hooks-status`, `/hooks-validate`, and `/hooks-reload` work and emit structured diagnostics when PI supports custom messages
+- `/hooks-status`, `/hooks-validate`, and `/hooks-reload` work; the Pi 0.80-capable TUI path persists diagnostics as custom entries outside model context, while older or non-TUI paths retain custom messages
 - `tool.before.bash`, `tool.after.read`, `tool.after.write`, and synthesized `file.changed` events reach smoke hooks
 - `tool:` actions produce a follow-up prompt in the current PI session, not imperative tool execution
 - `PI_YAML_HOOKS_ENABLE_USER_BASH=1` routes human `!` / `!!` commands through `tool.before.bash` only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.6.14",
+  "version": "2026.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-yaml-hooks",
-      "version": "2026.6.14",
+      "version": "2026.7.16",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.6.14",
+  "version": "2026.7.16",
   "description": "YAML hook automation for the PI coding agent: tool guards, session hooks, prompts, notifications, and bash actions.",
   "author": "Kristjan Pikhof <kristjan.pikhof@gmail.com> (https://github.com/KristjanPikhof)",
   "type": "module",

--- a/src/pi/adapter.test.ts
+++ b/src/pi/adapter.test.ts
@@ -58,6 +58,8 @@ class FakePiHarness {
   hasUI = true
   exposeAutocomplete = true
   confirmResult = true
+  idle = true
+  pendingMessages = false
   reloads = 0
   notificationsWithLevel: Array<{ message: string; type?: string }> = []
 
@@ -139,8 +141,8 @@ class FakePiHarness {
           return { id: this.sessionId }
         },
       },
-      isIdle: () => true,
-      hasPendingMessages: () => false,
+      isIdle: () => this.idle,
+      hasPendingMessages: () => this.pendingMessages,
       reload: async () => {
         this.reloads += 1
       },
@@ -184,8 +186,21 @@ class FakePiHarness {
     return await this.emit("before_agent_start", { type: "before_agent_start", prompt, systemPrompt })
   }
 
+  async agentStart(): Promise<void> {
+    await this.emit("agent_start")
+  }
+
   async agentEnd(): Promise<void> {
     await this.emit("agent_end")
+  }
+
+  async agentSettled(): Promise<void> {
+    await this.emit("agent_settled")
+  }
+
+  async agentRunEnd(): Promise<void> {
+    await this.agentStart()
+    await this.agentEnd()
   }
 
   async toolCall(toolName: string, toolCallId: string, input: Record<string, unknown> = {}): Promise<unknown> {
@@ -321,10 +336,95 @@ const cases: Case[] = [
         const harness = new FakePiHarness(projectDir)
         harness.register()
         await harness.sessionStart("new")
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         const expected = JSON.stringify(["trusted-created", "trusted-idle"])
         return JSON.stringify(harness.notifications) === expected
+          ? { ok: true }
+          : { ok: false, detail: `notifications=${JSON.stringify(harness.notifications)}` }
+      }),
+  },
+  {
+    name: "session.idle waits for agent_settled when agent_end is not yet idle",
+    run: async () =>
+      await withIsolatedProject(true, async (projectDir) => {
+        writeProjectHooks(
+          projectDir,
+          `hooks:
+  - event: session.idle
+    actions:
+      - notify: "settled-idle"
+`,
+        )
+
+        const harness = new FakePiHarness(projectDir)
+        harness.register()
+        await harness.agentStart()
+        harness.idle = false
+        await harness.agentEnd()
+        const notificationsAtAgentEnd = harness.notifications.length
+        harness.idle = true
+        await harness.agentSettled()
+
+        return notificationsAtAgentEnd === 0 && harness.notifications.join(",") === "settled-idle"
+          ? { ok: true }
+          : {
+              ok: false,
+              detail: `atAgentEnd=${notificationsAtAgentEnd}, notifications=${JSON.stringify(harness.notifications)}`,
+            }
+      }),
+  },
+  {
+    name: "session.idle deduplicates agent_end and agent_settled and re-arms on agent_start",
+    run: async () =>
+      await withIsolatedProject(true, async (projectDir) => {
+        writeProjectHooks(
+          projectDir,
+          `hooks:
+  - event: session.idle
+    actions:
+      - notify: "idle"
+`,
+        )
+
+        const harness = new FakePiHarness(projectDir)
+        harness.register()
+        await harness.agentStart()
+        await harness.agentEnd()
+        await harness.agentSettled()
+        await harness.agentStart()
+        await harness.agentEnd()
+        await harness.agentSettled()
+
+        return harness.notifications.join(",") === "idle,idle"
+          ? { ok: true }
+          : { ok: false, detail: `notifications=${JSON.stringify(harness.notifications)}` }
+      }),
+  },
+  {
+    name: "session.idle suppresses pending messages until the continuation settles",
+    run: async () =>
+      await withIsolatedProject(true, async (projectDir) => {
+        writeProjectHooks(
+          projectDir,
+          `hooks:
+  - event: session.idle
+    actions:
+      - notify: "idle"
+`,
+        )
+
+        const harness = new FakePiHarness(projectDir)
+        harness.register()
+        await harness.agentStart()
+        harness.pendingMessages = true
+        await harness.agentEnd()
+        await harness.agentSettled()
+        harness.pendingMessages = false
+        await harness.agentStart()
+        await harness.agentEnd()
+
+        return harness.notifications.join(",") === "idle"
           ? { ok: true }
           : { ok: false, detail: `notifications=${JSON.stringify(harness.notifications)}` }
       }),
@@ -469,7 +569,7 @@ const cases: Case[] = [
         const harness = new FakePiHarness(projectDir)
         harness.register()
         await harness.sessionStart("new")
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         return harness.notifications.length === 0
           ? { ok: true }
@@ -770,7 +870,7 @@ const cases: Case[] = [
         const harness = new FakePiHarness(projectDir)
         harness.register()
 
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         writeProjectHooks(
           projectDir,
@@ -781,7 +881,7 @@ const cases: Case[] = [
 `,
         )
         await harness.toolResult("edit", "call-3", { path: path.join(projectDir, ".pi", "hook", "hooks.yaml") })
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         writeProjectHooks(
           projectDir,
@@ -792,7 +892,7 @@ const cases: Case[] = [
 `,
         )
         await harness.toolResult("edit", "call-4", { path: path.join(projectDir, ".pi", "hook", "hooks.yaml") })
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         const expected = JSON.stringify(["idle-v1", "idle-v2", "idle-v2"])
         return JSON.stringify(harness.notifications) === expected
@@ -827,7 +927,7 @@ hooks: []
         const harness = new FakePiHarness(projectDir)
         harness.register()
 
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         writeFileSync(
           importedPath,
@@ -839,7 +939,7 @@ hooks: []
           "utf8",
         )
         await harness.toolResult("edit", "call-import-1", { path: importedPath })
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         writeFileSync(
           importedPath,
@@ -851,7 +951,7 @@ hooks: []
           "utf8",
         )
         await harness.toolResult("edit", "call-import-2", { path: importedPath })
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         const expected = JSON.stringify(["import-v1", "import-v2", "import-v2"])
         return JSON.stringify(harness.notifications) === expected
@@ -1060,7 +1160,7 @@ hooks: []
 
         const harness = new FakePiHarness(projectDir)
         harness.register()
-        await harness.agentEnd()
+        await harness.agentRunEnd()
 
         return harness.customMessages.some((message) => message.customType === "pi-yaml-hooks-diagnostics") &&
             harness.customMessages.some((message) => JSON.stringify(message.content).includes("validation issue"))

--- a/src/pi/diagnostics.test.ts
+++ b/src/pi/diagnostics.test.ts
@@ -16,24 +16,60 @@ interface CapturedMessage {
   readonly details?: unknown
 }
 
-interface FakePi {
-  readonly messages: CapturedMessage[]
-  readonly renderers: Map<string, unknown>
-  registerMessageRenderer<T>(type: string, render: (message: { content: unknown; details: T | undefined }, opts: { expanded: boolean }, theme: unknown) => unknown): void
-  sendMessage<T>(message: { customType: string; content: string; display: boolean; details?: T }): void
+interface CapturedEntry {
+  readonly customType: string
+  readonly data: unknown
 }
 
-function createFakePi(): FakePi {
+interface FakePi {
+  readonly messages: CapturedMessage[]
+  readonly entries: CapturedEntry[]
+  readonly renderers: Map<string, unknown>
+  readonly entryRenderers?: Map<string, unknown>
+  registerMessageRenderer<T>(type: string, render: (message: { content: unknown; details: T | undefined }, opts: { expanded: boolean }, theme: unknown) => unknown): void
+  registerEntryRenderer?(type: string, render: unknown): void
+  sendMessage<T>(message: { customType: string; content: string; display: boolean; details?: T }): void
+  appendEntry?(customType: string, data: unknown): void
+  on(type: string, handler: (event: unknown, ctx: { mode: string }) => void): void
+  startSession(mode: string): void
+}
+
+function createFakePi(options: { entryRenderer?: boolean; appendEntry?: boolean } = {}): FakePi {
   const messages: CapturedMessage[] = []
+  const entries: CapturedEntry[] = []
   const renderers = new Map<string, unknown>()
+  const entryRenderers = options.entryRenderer ? new Map<string, unknown>() : undefined
+  let sessionStart: ((event: unknown, ctx: { mode: string }) => void) | undefined
   return {
     messages,
+    entries,
     renderers,
+    ...(entryRenderers
+      ? {
+          entryRenderers,
+          registerEntryRenderer(type: string, render: unknown) {
+            entryRenderers.set(type, render)
+          },
+        }
+      : {}),
+    ...(options.appendEntry
+      ? {
+          appendEntry(customType: string, data: unknown) {
+            entries.push({ customType, data })
+          },
+        }
+      : {}),
     registerMessageRenderer(type, render) {
       renderers.set(type, render)
     },
     sendMessage(message) {
       messages.push(message)
+    },
+    on(type, handler) {
+      if (type === "session_start") sessionStart = handler
+    },
+    startSession(mode) {
+      sessionStart?.({}, { mode })
     },
   }
 }
@@ -51,11 +87,80 @@ const cases: Case[] = [
     },
   },
   {
+    name: "registers an entry renderer only when both entry capabilities exist",
+    run: () => {
+      const complete = createFakePi({ entryRenderer: true, appendEntry: true })
+      const missingSender = createFakePi({ entryRenderer: true })
+      registerHookDiagnostics(complete as never)
+      registerHookDiagnostics(missingSender as never)
+
+      const completeRegistered = complete.entryRenderers?.has(PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE) === true
+      const partialRegistered = missingSender.entryRenderers?.has(PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE) === true
+      return completeRegistered && !partialRegistered
+        ? { ok: true }
+        : { ok: false, detail: `complete=${completeRegistered}, partial=${partialRegistered}` }
+    },
+  },
+  {
     name: "PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE is the canonical pi-yaml-hooks-diagnostics string",
     run: () =>
       PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE === "pi-yaml-hooks-diagnostics"
         ? { ok: true }
         : { ok: false, detail: PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE },
+  },
+  {
+    name: "TUI diagnostics use context-free entries when both capabilities exist",
+    run: () => {
+      const pi = createFakePi({ entryRenderer: true, appendEntry: true })
+      registerHookDiagnostics(pi as never)
+      pi.startSession("tui")
+      const sections = [{ label: "details", lines: ["one"] }]
+      sendHookDiagnostics(pi as never, {
+        title: "Entry title",
+        level: "warning",
+        content: "entry content",
+        sections,
+      })
+
+      if (pi.messages.length !== 0 || pi.entries.length !== 1) {
+        return { ok: false, detail: `messages=${pi.messages.length}, entries=${pi.entries.length}` }
+      }
+      const entry = pi.entries[0]
+      const data = entry.data as { content?: string; title?: string; level?: string; sections?: unknown }
+      return entry.customType === PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE &&
+        data.content === "entry content" &&
+        data.title === "Entry title" &&
+        data.level === "warning" &&
+        JSON.stringify(data.sections) === JSON.stringify(sections)
+        ? { ok: true }
+        : { ok: false, detail: JSON.stringify(entry) }
+    },
+  },
+  {
+    name: "non-TUI diagnostics keep the custom-message fallback",
+    run: () => {
+      const pi = createFakePi({ entryRenderer: true, appendEntry: true })
+      registerHookDiagnostics(pi as never)
+      pi.startSession("json")
+      sendHookDiagnostics(pi as never, { title: "headless", level: "info", content: "fallback" })
+
+      return pi.entries.length === 0 && pi.messages.length === 1 && pi.messages[0].content === "fallback"
+        ? { ok: true }
+        : { ok: false, detail: `messages=${pi.messages.length}, entries=${pi.entries.length}` }
+    },
+  },
+  {
+    name: "partial entry capability keeps the custom-message fallback",
+    run: () => {
+      const pi = createFakePi({ appendEntry: true })
+      registerHookDiagnostics(pi as never)
+      pi.startSession("tui")
+      sendHookDiagnostics(pi as never, { title: "partial", level: "error", content: "fallback" })
+
+      return pi.entries.length === 0 && pi.messages.length === 1
+        ? { ok: true }
+        : { ok: false, detail: `messages=${pi.messages.length}, entries=${pi.entries.length}` }
+    },
   },
   {
     name: "sendHookDiagnostics emits a structured message with display=true",
@@ -178,6 +283,36 @@ const cases: Case[] = [
       return sawWarningBadge && sawDimSectionLabel
         ? { ok: true }
         : { ok: false, detail: `colorCalls=${JSON.stringify(colorCalls)}` }
+    },
+  },
+  {
+    name: "entry renderer reuses message formatting",
+    run: () => {
+      const pi = createFakePi({ entryRenderer: true, appendEntry: true })
+      registerHookDiagnostics(pi as never)
+      const renderer = pi.entryRenderers?.get(PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE) as (
+        entry: { data: { content: string; title: string; level: "error"; sections: Array<{ label: string; lines: string[] }> } },
+        opts: { expanded: boolean },
+        theme: { fg: (color: string, text: string) => string; bg: (color: string, text: string) => string },
+      ) => unknown
+      const colorCalls: string[] = []
+      const theme = {
+        fg: (color: string, text: string) => {
+          colorCalls.push(`${color}:${text}`)
+          return text
+        },
+        bg: (_color: string, text: string) => text,
+      }
+
+      renderer(
+        { data: { content: "entry", title: "entry title", level: "error", sections: [{ label: "sec", lines: ["line"] }] } },
+        { expanded: true },
+        theme,
+      )
+
+      return colorCalls.includes("error:[ERROR]") && colorCalls.includes("dim:sec")
+        ? { ok: true }
+        : { ok: false, detail: JSON.stringify(colorCalls) }
     },
   },
   {

--- a/src/pi/diagnostics.ts
+++ b/src/pi/diagnostics.ts
@@ -12,29 +12,77 @@ export interface HookDiagnosticsMessageDetails {
   }>
 }
 
+interface HookDiagnosticsEntryData extends HookDiagnosticsMessageDetails {
+  readonly content: string
+}
+
+interface EntryCapablePi {
+  registerEntryRenderer(
+    customType: string,
+    renderer: (
+      entry: { readonly data?: HookDiagnosticsEntryData },
+      options: { readonly expanded: boolean },
+      theme: RendererTheme,
+    ) => unknown,
+  ): void
+  appendEntry(customType: string, data: HookDiagnosticsEntryData): void
+}
+
+type MessageRenderer = Parameters<ExtensionAPI["registerMessageRenderer"]>[1]
+type RendererTheme = Parameters<MessageRenderer>[2]
+
+const entryEnabled = new WeakMap<ExtensionAPI, boolean>()
+
+function hasEntryCapabilities(pi: ExtensionAPI): pi is ExtensionAPI & EntryCapablePi {
+  const candidate = pi as unknown as Partial<EntryCapablePi>
+  return typeof candidate.registerEntryRenderer === "function" && typeof candidate.appendEntry === "function"
+}
+
+function renderDiagnostics(
+  content: unknown,
+  details: HookDiagnosticsMessageDetails | undefined,
+  expanded: boolean,
+  theme: RendererTheme,
+): Box {
+  const level = details?.level ?? "info"
+  const title = details?.title ?? "pi-yaml-hooks diagnostics"
+  const badgeColor = level === "error" ? "error" : level === "warning" ? "warning" : "dim"
+  const lines = [`${theme.fg(badgeColor, `[${level.toUpperCase()}]`)} ${title}`, String(content)]
+
+  if (expanded && details?.sections) {
+    for (const section of details.sections) {
+      lines.push("")
+      lines.push(theme.fg("dim", section.label))
+      lines.push(...section.lines)
+    }
+  }
+
+  const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text))
+  box.addChild(new Text(lines.join("\n"), 0, 0))
+  return box
+}
+
 export function registerHookDiagnostics(pi: ExtensionAPI): void {
   pi.registerMessageRenderer<HookDiagnosticsMessageDetails>(
     PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE,
-    (message, { expanded }, theme) => {
-      const details = message.details
-      const level = details?.level ?? "info"
-      const title = details?.title ?? "pi-yaml-hooks diagnostics"
-      const badgeColor = level === "error" ? "error" : level === "warning" ? "warning" : "dim"
-      const lines = [`${theme.fg(badgeColor, `[${level.toUpperCase()}]`)} ${title}`, String(message.content)]
-
-      if (expanded && details?.sections) {
-        for (const section of details.sections) {
-          lines.push("")
-          lines.push(theme.fg("dim", section.label))
-          lines.push(...section.lines)
-        }
-      }
-
-      const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text))
-      box.addChild(new Text(lines.join("\n"), 0, 0))
-      return box
-    },
+    (message, { expanded }, theme) => renderDiagnostics(message.content, message.details, expanded, theme),
   )
+
+  const supportsEntries = hasEntryCapabilities(pi)
+  entryEnabled.set(pi, false)
+  pi.on("session_start", (_event, ctx) => {
+    entryEnabled.set(pi, supportsEntries && ctx.mode === "tui")
+  })
+
+  if (supportsEntries) {
+    pi.registerEntryRenderer(
+      PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE,
+      (entry, { expanded }, theme) => {
+        const data = entry.data
+        return renderDiagnostics(data?.content, data, expanded, theme)
+      },
+    )
+  }
 }
 
 export function sendHookDiagnostics(
@@ -46,14 +94,24 @@ export function sendHookDiagnostics(
     readonly sections?: HookDiagnosticsMessageDetails["sections"]
   },
 ): void {
+  const details: HookDiagnosticsMessageDetails = {
+    title: message.title,
+    level: message.level,
+    ...(message.sections ? { sections: message.sections } : {}),
+  }
+
+  if (entryEnabled.get(pi) && hasEntryCapabilities(pi)) {
+    pi.appendEntry(PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE, {
+      content: message.content,
+      ...details,
+    })
+    return
+  }
+
   pi.sendMessage<HookDiagnosticsMessageDetails>({
     customType: PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE,
     content: message.content,
     display: true,
-    details: {
-      title: message.title,
-      level: message.level,
-      ...(message.sections ? { sections: message.sections } : {}),
-    },
+    details,
   })
 }

--- a/src/pi/diagnostics.ts
+++ b/src/pi/diagnostics.ts
@@ -71,11 +71,13 @@ export function registerHookDiagnostics(pi: ExtensionAPI): void {
   const supportsEntries = hasEntryCapabilities(pi)
   entryEnabled.set(pi, false)
   pi.on("session_start", (_event, ctx) => {
-    entryEnabled.set(pi, supportsEntries && ctx.mode === "tui")
+    const mode = (ctx as unknown as { readonly mode?: unknown }).mode
+    entryEnabled.set(pi, supportsEntries && mode === "tui")
   })
 
   if (supportsEntries) {
-    pi.registerEntryRenderer(
+    const entryPi = pi as unknown as EntryCapablePi
+    entryPi.registerEntryRenderer(
       PI_YAML_HOOKS_DIAGNOSTICS_MESSAGE_TYPE,
       (entry, { expanded }, theme) => {
         const data = entry.data

--- a/src/pi/register-adapter.ts
+++ b/src/pi/register-adapter.ts
@@ -49,7 +49,8 @@ import { registerUserBashInterception } from "./user-bash.js";
  * Installs:
  * - `tool_call`    → runtime `tool.execute.before` (+ block-tool response)
  * - `tool_result`  → Phase 1 snapshot-hook + runtime `tool.execute.after`
- * - `agent_end`    → runtime `session.idle` (when idle + no pending messages)
+ * - `agent_end` / `agent_settled`
+ *                  → runtime `session.idle` (when idle + no pending messages)
  * - `session_start`→ runtime `session.created` (on new/startup)
  * - `session_shutdown` / `session_before_switch`
  *                  → Phase 1 worker flush + runtime `session.deleted`
@@ -169,21 +170,44 @@ export function registerAdapter(pi: ExtensionAPI): void {
     }
   });
 
-  // ---- agent_end ----
-  // Fire session.idle once the agent loop ends AND no messages are queued.
-  pi.on("agent_end", async (_event, ctx: ExtensionContext): Promise<void> => {
+  // ---- agent_start / agent_end / agent_settled ----
+  // Pi <=0.79 is idle at agent_end. Pi >=0.80 emits agent_settled only after
+  // retries, compaction, and queued continuations are exhausted. Register the
+  // newer event through a narrow compatibility shape so older SDK types and
+  // runtimes remain supported without version checks.
+  let sessionIdleDispatched = false;
+
+  pi.on("agent_start", () => {
+    sessionIdleDispatched = false;
+  });
+
+  const dispatchSessionIdle = async (ctx: ExtensionContext): Promise<void> => {
+    if (sessionIdleDispatched) return;
+
     rememberContext(ctx.cwd, ctx);
     const sessionId = safeGetSessionId(ctx.sessionManager);
     if (!sessionId) return;
     if (!ctx.isIdle || !ctx.isIdle()) return;
     if (ctx.hasPendingMessages && ctx.hasPendingMessages()) return;
 
+    sessionIdleDispatched = true;
     try {
       const runtime = getRuntimeFor(ctx.cwd);
       await runtime.event(buildSessionIdleEvent(sessionId));
     } catch (error) {
       reportDispatchFailure(logger, { cwd: ctx.cwd, event: "session.idle", sessionId }, error);
     }
+  };
+
+  pi.on("agent_end", async (_event, ctx: ExtensionContext): Promise<void> => {
+    await dispatchSessionIdle(ctx);
+  });
+
+  const settledEventApi = pi as unknown as {
+    on(event: "agent_settled", handler: (_event: unknown, ctx: ExtensionContext) => Promise<void>): void;
+  };
+  settledEventApi.on("agent_settled", async (_event, ctx): Promise<void> => {
+    await dispatchSessionIdle(ctx);
   });
 
   // ---- session_start / session_shutdown / session_before_switch ----


### PR DESCRIPTION
## Description

Harden the Pi host integration for newer lifecycle and diagnostics capabilities without dropping the existing Pi 0.74/0.79 compatibility paths. Pi 0.80-capable hosts can now wait until an agent run is fully settled before emitting `session.idle`, and TUI diagnostics can persist as custom entries that stay outside model context.

Older Pi runtimes and non-TUI sessions keep the existing `agent_end` and custom-message fallbacks. This prevents hooks from observing a premature idle state during retries, compaction, or queued continuations, while keeping diagnostics visible on hosts that do not expose the newer entry APIs.

The package and lockfile version are also advanced to `2026.7.16` so published artifacts carry the branch's release date.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Register `agent_settled` through a narrow compatibility shape while retaining `agent_end` for older hosts. Reset idle state on `agent_start`, dispatch only when the host reports idle with no pending messages, and deduplicate `agent_end`/`agent_settled` so each run emits `session.idle` once.
- Add a shared diagnostics renderer for custom messages and custom entries. Use entries only when both `registerEntryRenderer` and `appendEntry` exist and the session is TUI; otherwise continue using `sendMessage`.
- Add regression coverage for delayed settlement, pending continuations, per-run idle deduplication, complete and partial entry capabilities, TUI/non-TUI routing, and shared rendering behavior.
- Update the README and hook/debugging references to document Pi 0.80-capable behavior and the legacy fallback paths.
- Update `package.json` and `package-lock.json` from `2026.6.14` to the current date-based version, `2026.7.16`.

## How to Test

1. Run `npm run typecheck`.
2. Run `npm run test:internal`.
3. Run `npm pack --dry-run` and confirm the artifact is named `pi-yaml-hooks-2026.7.16.tgz`.
4. Confirm the adapter cases cover `agent_end` followed by `agent_settled`, pending-message suppression, and re-arming on the next `agent_start`.
5. Confirm the diagnostics cases route TUI sessions to entries only with both required capabilities and retain custom messages for non-TUI or partial-capability hosts.

Verified on this branch:

- `npm run typecheck`
- `npm run test:internal` (20 test files; adapter 38/38 and diagnostics 13/13)
- `npm pack --dry-run` (`pi-yaml-hooks-2026.7.16.tgz`)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [ ] No new warnings or console errors introduced

## Related Issues

None referenced in the branch name or commit history.

## Screenshots

Not applicable. This changes host lifecycle dispatch and diagnostics routing; renderer output remains shared with the existing custom-message path.
