### PR TITLE
Prepare Pi 0.80.10 compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Agent contract for `pi-yaml-hooks`. Facts only; tutorials in `docs/`.
 
 - Runtime: one `pi-yaml-hooks` package with native Pi and OMP extension entries. Type-only `pi-yaml-hooks/types` exports `HookConfig`, `HookEvent`, `BashHookContext`, `SessionDeletedReason`; smoke: `src/public-types-smoke.test.ts`.
 - Package engine: Node `>=22.19.0`; macOS/Linux only (`src/pi/register-adapter.ts` guards win32). OMP runtime smoke is verified with Bun `1.3.14`.
-- Pi host peers: `@earendil-works/pi-coding-agent` + `@earendil-works/pi-tui` as optional `*`; dev-tested at `0.79.3`; compatibility matrix covers `0.74.0` + `0.79.3`. Current live Pi evidence is `0.80.7`, not a widened claim.
+- Pi host peers: `@earendil-works/pi-coding-agent` + `@earendil-works/pi-tui` as optional `*`; dev-tested at `0.80.10`; compatibility matrix covers exact `0.74.0` + `0.79.3` + `0.80.10`. Current live Pi evidence is exact `0.80.10`, including `--no-builtin-tools`; this is not a broader range claim.
 - OMP host peers: `@oh-my-pi/pi-coding-agent` + `@oh-my-pi/pi-tui` as optional `*`; compile/runtime-tested at `17.0.1`.
 - No direct `@mariozechner/*` host deps. Transitive `@mariozechner/clipboard` may appear under Pi SDK packages in `package-lock.json`.
 - `package-lock.json` is canonical; no bun.lock.
@@ -51,7 +51,7 @@ Agent contract for `pi-yaml-hooks`. Facts only; tutorials in `docs/`.
 - Build: `npm run build` before direct `dist/**/*.test.js`; emits `dist/extensions/*`.
 - Full tests: `npm run test:internal` = build + `node scripts/run-tests.mjs`; known timed-hook flake policy is in `docs/maintaining.md`.
 - `npm test` is consumer no-op; not validation. No lint script exists.
-- Pi SDK matrix: `npm run compat:sdk-matrix` checks `0.74.0` + `0.79.3`; `:future` is advisory only.
+- Pi SDK matrix: `npm run compat:sdk-matrix` checks exact `0.74.0` + `0.79.3` + `0.80.10`; `:future` is advisory only.
 - Dual-host gate: `npm run compat:host-matrix -- --dry-run` previews; `npm run compat:host-matrix` runs Pi/OMP compile, tests, OMP smoke, package checks, cleanup, and drift assertions.
 - Runtime smokes: `bash scripts/smoke/pi-runtime-smoke.sh --automated` and `bash scripts/smoke/omp-runtime-smoke.sh`; both use isolated native package discovery.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If a trusted project also has project hooks, the summary includes both scopes:
 - `bash` on `$PATH` (override with `PI_YAML_HOOKS_BASH_EXECUTABLE`)
 - Pi with the verified SDK compatibility pairs described below, or OMP
 
-The Pi SDK matrix verifies the retained 0.74.0 floor and current 0.79.3 pair. The end-to-end runtime smoke was run with Pi 0.80.7 and OMP 17.0.1. These are tested versions, not a broader support claim.
+The Pi SDK matrix verifies exact 0.74.0, 0.79.3, and 0.80.10 pairs. The end-to-end runtime smoke passed with Pi 0.80.10, including an isolated `--no-builtin-tools` scenario, and with OMP 17.0.1. These are tested versions, not a broader support claim.
 
 Windows is unsupported.
 
@@ -107,7 +107,7 @@ Before widening Pi peer support or merging SDK-sensitive changes, run:
 npm run compat:sdk-matrix
 ```
 
-The matrix checks both the legacy 0.74.0 SDK floor and the current Pi 0.79.3 SDK pair (`@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`). It creates a temporary copy of the repository, installs each SDK pair in that copy only, then runs `npm run typecheck` and `npm run test:internal`. The working checkout's `package.json`, `package-lock.json`, and normal `node_modules` are not mutated.
+The matrix checks exact Pi 0.74.0, 0.79.3, and 0.80.10 SDK pairs (`@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui`). It creates a temporary copy of the repository, installs and asserts each requested pair in that copy only, then runs `npm run typecheck` and `npm run test:internal`. The working checkout's `package.json`, `package-lock.json`, and normal `node_modules` are not mutated.
 
 `npm test` remains a consumer-facing no-op. Use `npm run test:internal` directly in the working checkout for full validation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Hook bash, follow-up prompts, and host UI actions onto tool calls and session ev
 
 These are the details that matter most when authoring hooks in Pi or OMP:
 
-- The Pi SDK compatibility matrix retains 0.74.0 and 0.79.3. Runtime smoke testing used Pi 0.80.7 and OMP 17.0.1; this does not claim support for a wider version range.
+- The Pi SDK compatibility matrix covers exact 0.74.0, 0.79.3, and 0.80.10 pairs. Runtime smoke testing used Pi 0.80.10 and OMP 17.0.1; this does not claim support for a wider version range.
 - Only one global root config and one project root config are discovered.
 - Project-root imports require pi-yaml-hooks project-hook trust. Host package trust is separate and does not activate project hooks here. Global-root imports require `PI_YAML_HOOKS_ALLOW_GLOBAL_IMPORTS=1`; package imports require `PI_YAML_HOOKS_ALLOW_PACKAGE_IMPORTS=1`; project imports outside the trust anchor require `PI_YAML_HOOKS_ALLOW_PROJECT_IMPORTS_OUTSIDE_TRUST_ANCHOR=1`.
 - OMP uses the active profile's agent directory and separate trust store. Global discovery stays inside that agent directory. Project discovery checks native `.omp` before legacy `.pi` within each directory while walking upward; a legacy fallback still requires OMP trust.

--- a/docs/hooks-reference.md
+++ b/docs/hooks-reference.md
@@ -525,7 +525,7 @@ Use the repeatable host matrix and runtime smoke gates in [`maintaining.md`](./m
 
 The current evidence separates compile compatibility from live runtime proof:
 
-- Pi compatibility remains pinned to the `0.74.0` and `0.79.3` SDK matrix. A live Pi `0.80.7` smoke passed, but that observation alone does not widen the compatibility claim.
+- Pi compatibility is pinned to exact `0.74.0`, `0.79.3`, and `0.80.10` SDK matrix rows. The live Pi `0.80.10` smoke also covers native package discovery and an isolated `--no-builtin-tools` lifecycle scenario.
 - OMP compile, internal-suite, package-install, RPC, and TUI smoke evidence is pinned to `17.0.1`.
 - Pi startup/new and OMP startup/new produce `session.created`; resume/fork do not.
 - OMP derives idle from the post-stop `agent_end`, after continuation-capable `session_stop` handlers have settled.

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -22,7 +22,7 @@ The matrix uses isolated temporary copies, excludes `.git`, `.trekoon`, `node_mo
 
 | Gate | Pinned evidence | What must pass |
 |---|---|---|
-| Pi SDK compatibility | `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` at `0.74.0` and `0.79.3` | Typecheck plus all discovered internal test files for each pair. These remain the compatibility claims. |
+| Pi SDK compatibility | `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` at exact `0.74.0`, `0.79.3`, and `0.80.10` | Exact installed-version assertions, typecheck, and all discovered internal test files for each pair. |
 | OMP SDK compatibility | `@oh-my-pi/pi-coding-agent` and `@oh-my-pi/pi-tui` at `17.0.1` | Isolated dependency substitution, typecheck, and the complete internal suite. |
 | OMP runtime | Observed OMP CLI, Bun, and installed `pi-yaml-hooks` versions | `scripts/smoke/omp-runtime-smoke.sh`, including native packed install, RPC behavior, real TUI autocomplete, lifecycle mapping, active named-profile paths, trust, and cleanup. |
 | Package contract | Current `package.json`, canonical `package-lock.json`, and packed artifact | Both host manifest entries and public extension stubs exist; declared files are packed; tests, build debris, and undeclared targets are absent. |
@@ -36,7 +36,7 @@ The package gate must confirm:
 - `pi.extensions` points to `./extensions/pi-yaml-hooks/index.ts`
 - `omp.extensions` points to `./extensions/omp-yaml-hooks/index.ts`
 - Pi and OMP host peers remain optional so installing one host does not force the other runtime
-- dev SDK specs resolve to Pi `0.79.3` and OMP `17.0.1`
+- dev SDK specs resolve to Pi `0.80.10` and OMP `17.0.1`
 - source entries, generated `dist` entries, and public exports are present in `npm pack`
 - package inventory has no `*.test.*`, `*.tsbuildinfo`, or other build debris
 
@@ -57,15 +57,15 @@ Both scripts stage a checkout copy, then use isolated home, project, profile, np
 |---|---|---|
 | Host versions | Records Pi, both `@earendil-works` SDK packages, and Node | Records the OMP CLI, Bun, and installed `pi-yaml-hooks` package |
 | Storage and trust | `.pi` global/project paths, active Pi trust store, default and override logs | Active named-profile `.omp` runtime paths, native project paths, OMP trust store, default log, and no Pi-state leakage |
-| Events | Tool before/after, synthesized file changes, created/idle/deleted, opt-in `user_bash` | Tool before, created/idle/deleted, and opt-in `user_bash` |
+| Events | Tool before/after, synthesized file changes, created/idle/deleted, opt-in `user_bash`; a separate `--no-builtin-tools` RPC process proves created/deleted lifecycle | Tool before, created/idle/deleted, and opt-in `user_bash` |
 | UI and prompts | RPC actions, prompt awareness, diagnostics, and real PTY autocomplete | RPC actions/headless degradation, prompt awareness, diagnostics, and real tmux TUI autocomplete with same-process lazy refresh |
 | Cleanup | Temporary install and process cleanup; real-home and checkout package/`dist` checksums unchanged | Temporary profile, package stage, HTTP server, and private tmux cleanup; checkout package/`dist` checksum unchanged |
 
 Default-profile and named-profile OMP storage are both covered by internal tests. The standalone OMP smoke records runtime evidence only for its active named profile.
 
-Current standalone runtime evidence used Pi `0.80.7` with SDK `0.80.7`, and OMP CLI `17.0.1` with the printed Bun and installed plugin versions. The OMP SDK `17.0.1` claim comes from the host matrix, not the standalone runtime smoke. The Pi observation does not replace the published `0.74.0`/`0.79.3` compatibility matrix.
+Current standalone runtime evidence used Pi `0.80.10` with coding-agent and TUI SDK `0.80.10`, and OMP CLI `17.0.1` with the printed Bun and installed plugin versions. The Pi smoke passed all four acceptance rows, including native package discovery, RPC commands and diagnostics, PTY autocomplete, lifecycle hooks, and a graceful isolated `--no-builtin-tools` process. The OMP SDK `17.0.1` claim comes from the host matrix, not the standalone runtime smoke.
 
-The completed `2026-07-17` gate recorded `test_files=24 pass=24 fail=0` for each Pi pair and OMP `17.0.1`, OMP runtime `A23` through `A26` at `4/4`, and a package inventory of `140` files with `11` required entries, `0` missing, and `0` forbidden. Cleanup and package-file drift checks passed.
+The completed `2026-07-18` gates recorded `test_files=24 pass=24 fail=0` for each exact Pi `0.74.0`, `0.79.3`, and `0.80.10` pair and OMP `17.0.1`. The Pi runtime smoke recorded `A23P` through `A26P` at `4/4`, exact Pi/coding-agent/TUI `0.80.10`, and unchanged checkout and real Pi home surfaces. The OMP runtime recorded `A23` through `A26` at `4/4`; package verification recorded `140` files with `11` required entries, `0` missing, and `0` forbidden. Cleanup and package-file drift checks passed.
 
 ## Widen a host claim
 
@@ -79,7 +79,7 @@ Do not widen an OMP claim from typechecking alone. Before naming a newer OMP lin
 6. Prove tool, lifecycle, `user_bash`, prompt, diagnostic, RPC UI, no-UI, and real TUI autocomplete rows.
 7. Keep exact version output, event/log excerpts, path selections, package inventory, and cleanup assertions.
 
-Apply the same rule to a future Pi line: the advisory future SDK probe is not enough. Keep `0.74.0` and `0.79.3` claims until the exact matrix and live runtime smoke both pass.
+Apply the same rule to a future Pi line: the advisory future SDK probe is not enough. Keep the exact `0.74.0`, `0.79.3`, and `0.80.10` claims until that line's exact matrix and live runtime smoke both pass.
 
 ## Handle the known timed-hook flake
 
@@ -112,7 +112,7 @@ For every host-sensitive change, retain:
 | `npm run typecheck` | TypeScript verification after source changes |
 | `npm run build` | Build before direct `dist/**/*.test.js` execution |
 | `npm run test:internal` | Complete internal suite; the timed-hook policy above applies |
-| `npm run compat:sdk-matrix` | Pi `0.74.0`/`0.79.3` compatibility only |
+| `npm run compat:sdk-matrix` | Exact Pi `0.74.0`/`0.79.3`/`0.80.10` compatibility |
 | `npm run compat:sdk-matrix:future` | Advisory Pi future-line probe; never widens claims by itself |
 | `npm run compat:host-matrix -- --dry-run` | Print exact dual-host matrix versions and commands without installs |
 | `npm run compat:host-matrix` | Full Pi/OMP compile, test, runtime, package, cleanup, and drift gate |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -11,7 +11,7 @@ This guide installs `pi-yaml-hooks` natively in Pi or OMP, then gives you a safe
 
 Windows is unsupported because the hook runner expects a POSIX `bash`.
 
-The package lists both hosts' SDK packages as optional peer dependencies and as dev dependencies for local typechecking only. The retained Pi compatibility checks use SDK 0.74.0 and 0.79.3. End-to-end runtime behavior was tested with Pi 0.80.7 and OMP 17.0.1. Do not read those runtime versions as a broader support range.
+The package lists both hosts' SDK packages as optional peer dependencies and as dev dependencies for local typechecking only. Pi compatibility checks use exact SDK pairs 0.74.0, 0.79.3, and 0.80.10. End-to-end runtime behavior was tested with Pi 0.80.10 and OMP 17.0.1. Do not read those tested versions as a broader support range.
 
 ## Install the extension
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.7.16",
+  "version": "2026.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-yaml-hooks",
-      "version": "2026.7.16",
+      "version": "2026.7.18",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@earendil-works/pi-coding-agent": "^0.79.3",
-        "@earendil-works/pi-tui": "^0.79.3",
+        "@earendil-works/pi-coding-agent": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@oh-my-pi/pi-coding-agent": "^17.0.1",
         "@oh-my-pi/pi-tui": "^17.0.1",
         "@types/node": "^22.19.21",
@@ -150,16 +150,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.3.tgz",
-      "integrity": "sha512-B3rAyw4/f1l3EYjQpCKpevzuBIPjYor6fHxPHQpLMdn/NTv3536i1P4ZrsyFkKpXqJWH66xKK5hyf8sqRe3dGA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.3",
-        "@earendil-works/pi-ai": "^0.79.3",
-        "@earendil-works/pi-tui": "^0.79.3",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -171,8 +171,9 @@
         "jiti": "2.7.0",
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -648,12 +649,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.3",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -663,15 +664,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -680,20 +682,20 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.3.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -930,15 +932,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -953,6 +964,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -976,9 +1007,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -996,13 +1027,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1649,16 +1673,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -1850,9 +1874,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1860,15 +1884,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1904,6 +1927,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -1970,9 +2006,9 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2013,9 +2049,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2087,14 +2123,14 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.3.tgz",
-      "integrity": "sha512-cpmkEM1aEuGUx6YZM36VlzpulwLzqD5T2cUEkGHndDTNGEbnn5sj/9SYm+QBfKjvZsWoHfZuFBnu4+hh96/FbA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -5083,16 +5119,16 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.7.16",
+  "version": "2026.7.18",
   "description": "YAML hook automation for the Pi and OMP coding agents: tool guards, session hooks, prompts, notifications, and bash actions.",
   "author": "Kristjan Pikhof <kristjan.pikhof@gmail.com> (https://github.com/KristjanPikhof)",
   "type": "module",
@@ -116,8 +116,8 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "^0.79.3",
-    "@earendil-works/pi-tui": "^0.79.3",
+    "@earendil-works/pi-coding-agent": "^0.80.10",
+    "@earendil-works/pi-tui": "^0.80.10",
     "@oh-my-pi/pi-coding-agent": "^17.0.1",
     "@oh-my-pi/pi-tui": "^17.0.1",
     "@types/node": "^22.19.21",

--- a/scripts/check-host-matrix.sh
+++ b/scripts/check-host-matrix.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PI_SDK_SPECS=("0.74.0" "0.79.3")
+PI_SDK_SPECS=("0.74.0" "0.79.3" "0.80.10")
 OMP_SDK_SPEC="17.0.1"
 DRY_RUN=0
 MATRIX_ROOT=""
@@ -267,12 +267,13 @@ run_pi_matrix() {
     return "$pipeline_status"
   fi
 
-  node --input-type=module - "$log_file" "$EXPECTED_TEST_FILES" "$EXPECTED_TEST_PASS" <<'NODE'
+  node --input-type=module - "$log_file" "$EXPECTED_TEST_FILES" "$EXPECTED_TEST_PASS" "${PI_SDK_SPECS[@]}" <<'NODE'
 import { readFileSync } from "node:fs";
 const text = readFileSync(process.argv[2], "utf8");
 const expectedFiles = Number(process.argv[3]);
 const expectedPass = Number(process.argv[4]);
-for (const version of ["0.74.0", "0.79.3"]) {
+const versions = process.argv.slice(5);
+for (const version of versions) {
   const start = text.indexOf(`==> Checking Pi SDK ${version} in `);
   const end = text.indexOf(`==> Pi SDK ${version} passed`, start);
   if (start < 0 || end < 0) throw new Error(`missing completed Pi SDK section for ${version}`);

--- a/scripts/check-sdk-matrix.sh
+++ b/scripts/check-sdk-matrix.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DRY_RUN=0
 INCLUDE_FUTURE=0
-SDK_SPECS=("0.74.0" "0.79.3")
+SDK_SPECS=("0.74.0" "0.79.3" "0.80.10")
 
 usage() {
   cat <<'USAGE'
@@ -17,12 +17,13 @@ node_modules are not modified; each SDK spec is installed in a throwaway copy.
 Default matrix:
   - @earendil-works/pi-coding-agent@0.74.0 and @earendil-works/pi-tui@0.74.0
   - @earendil-works/pi-coding-agent@0.79.3 and @earendil-works/pi-tui@0.79.3
+  - @earendil-works/pi-coding-agent@0.80.10 and @earendil-works/pi-tui@0.80.10
 
 Options:
   --dry-run         Print the matrix and commands without creating temp installs.
-  --include-future Include the gated 0.80.x future target. This is advisory only and
+  --include-future Include the gated 0.81.x future target. This is advisory only and
                    does not change compatibility claims or package metadata.
-  --versions        Override SDK specs, for example: --versions "0.74.0 0.79.3".
+  --versions        Override SDK specs, for example: --versions "0.74.0 0.79.3 0.80.10".
   -h, --help        Show this help.
 USAGE
 }
@@ -61,7 +62,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$INCLUDE_FUTURE" -eq 1 ]]; then
-  SDK_SPECS+=("0.80.x")
+  SDK_SPECS+=("0.81.x")
 fi
 
 # Track every temp dir so a single cleanup_all wipes them on EXIT/INT/TERM.
@@ -113,7 +114,7 @@ For each SDK spec, the script will:
   5. run npm run test:internal
   6. delete the temporary copy
 
-Future gate: pass --include-future to try 0.80.x without changing compatibility claims or package metadata.
+Future gate: pass --include-future to try 0.81.x without changing compatibility claims or package metadata.
 
 P2-9 note: the matrix tests include src/pi/adapter.test.ts, which pins known
 SDK-emitted "stale session-bound" error messages against
@@ -131,6 +132,7 @@ if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "[dry-run] SDK $spec"
     echo "[dry-run] npm install --no-audit --no-fund"
     echo "[dry-run] npm install --no-audit --no-fund --no-save @earendil-works/pi-coding-agent@$spec @earendil-works/pi-tui@$spec"
+    echo "[dry-run] assert coding-agent and pi-tui resolve to the same version; exact specs must equal $spec"
     echo "[dry-run] npm run typecheck"
     echo "[dry-run] npm run test:internal"
   done
@@ -151,6 +153,24 @@ for spec in "${SDK_SPECS[@]}"; do
     npm install --no-audit --no-fund --no-save \
       "@earendil-works/pi-coding-agent@$spec" \
       "@earendil-works/pi-tui@$spec"
+    node --input-type=module - "$spec" <<'NODE'
+import { readFileSync } from "node:fs";
+
+const requested = process.argv[2];
+function packageVersion(name) {
+  return JSON.parse(readFileSync(`node_modules/${name}/package.json`, "utf8")).version;
+}
+const codingAgent = packageVersion("@earendil-works/pi-coding-agent");
+const tui = packageVersion("@earendil-works/pi-tui");
+if (codingAgent !== tui) {
+  throw new Error(`Pi SDK packages resolved differently: coding-agent=${codingAgent} tui=${tui} requested=${requested}`);
+}
+const exactSemver = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+if (exactSemver.test(requested) && codingAgent !== requested) {
+  throw new Error(`Pi SDK exact-version mismatch: resolved=${codingAgent} requested=${requested}`);
+}
+console.log(`Pi SDK versions: requested=${requested} coding-agent=${codingAgent} tui=${tui}`);
+NODE
     npm run typecheck
     npm run test:internal
   )

--- a/scripts/smoke/pi-runtime-smoke.sh
+++ b/scripts/smoke/pi-runtime-smoke.sh
@@ -6,6 +6,7 @@ VALID_FIXTURE="$ROOT_DIR/scripts/smoke/pi-runtime-smoke-hooks.yaml"
 INVALID_FIXTURE="$ROOT_DIR/scripts/smoke/pi-runtime-smoke-invalid-hooks.yaml"
 MODE="manual"
 MANUAL_DIR=""
+PI_TARGET_VERSION="0.80.10"
 
 case "${1:-}" in
   --automated)
@@ -174,8 +175,6 @@ const targets = [
   path.join(home, ".pi", "agent", "trusted-projects.json"),
   path.join(home, ".pi", "agent", "npm", "node_modules", "pi-yaml-hooks"),
   path.join(home, ".pi", "agent", "logs", "pi-yaml-hooks.ndjson"),
-  path.join(home, ".npm", "_logs"),
-  path.join(home, ".npm", "_update-notifier-last-checked"),
 ];
 const hash = crypto.createHash("sha256");
 function add(target, relative = "") {
@@ -251,7 +250,7 @@ import { spawn } from "node:child_process";
 const [piBin, projectDir, transcriptPath, stderrPath, mode, sessionDir, eventsPath] = process.argv.slice(2);
 const transcript = fs.createWriteStream(transcriptPath, { flags: "a" });
 const stderr = fs.createWriteStream(stderrPath, { flags: "a" });
-const child = spawn(piBin, [
+const args = [
   "--mode", "rpc",
   "--offline",
   "--provider", "smoke",
@@ -259,7 +258,9 @@ const child = spawn(piBin, [
   "--api-key", "smoke-key",
   "--session-dir", sessionDir,
   "--no-context-files",
-], { cwd: projectDir, env: process.env, stdio: ["pipe", "pipe", "pipe"] });
+];
+if (mode === "no-builtins") args.push("--no-builtin-tools");
+const child = spawn(piBin, args, { cwd: projectDir, env: process.env, stdio: ["pipe", "pipe", "pipe"] });
 
 let nextId = 0;
 let stdoutBuffer = "";
@@ -416,6 +417,10 @@ try {
     await rpc("get_commands");
     await slash("/hooks-status");
     await slash("/hooks-tail-log --path");
+    await slash("/hooks-validate");
+  } else if (mode === "no-builtins") {
+    await rpc("get_commands");
+    await slash("/hooks-status");
     await slash("/hooks-validate");
   } else {
     throw new Error(`unknown mode: ${mode}`);
@@ -624,6 +629,15 @@ run_automated() {
   local pass_count=0
   local interactive_row=""
   local cleanup_complete=0
+  local isolated_env=(
+    HOME="$isolated_home"
+    USERPROFILE="$isolated_home"
+    PI_CODING_AGENT_DIR="$agent_dir"
+    npm_config_cache="$smoke_root/npm-cache"
+    npm_config_userconfig="$smoke_root/npmrc"
+    npm_config_global=false
+    NPM_CONFIG_GLOBAL=false
+  )
 
   cleanup() {
     if [[ -n "$mock_pid" ]] && kill -0 "$mock_pid" >/dev/null 2>&1; then
@@ -664,8 +678,7 @@ YAML
   local pack_json="$transcript_dir/npm-pack.json"
   (
     cd "$package_stage"
-    HOME="$isolated_home" USERPROFILE="$isolated_home" npm_config_cache="$smoke_root/npm-cache" \
-      npm_config_userconfig="$smoke_root/npmrc" npm pack --json --pack-destination "$artifact_dir"
+    env "${isolated_env[@]}" npm pack --json --pack-destination "$artifact_dir"
   ) > "$pack_json"
   assert_dir "$package_stage/dist"
   local packed_name
@@ -686,15 +699,14 @@ NODE
   local install_out="$transcript_dir/pi-install.txt"
   (
     cd "$project_dir"
-    HOME="$isolated_home" USERPROFILE="$isolated_home" PI_CODING_AGENT_DIR="$agent_dir" \
-      "$pi_bin" install "$package_source"
+    env "${isolated_env[@]}" "$pi_bin" install "$package_source"
   ) > "$install_out" 2>&1
   assert_contains "$install_out" "Installed $package_source"
+  assert_dir "$smoke_root/npm-cache/_logs"
   local list_out="$transcript_dir/pi-list.txt"
   (
     cd "$project_dir"
-    HOME="$isolated_home" USERPROFILE="$isolated_home" PI_CODING_AGENT_DIR="$agent_dir" \
-      "$pi_bin" list
+    env "${isolated_env[@]}" "$pi_bin" list
   ) > "$list_out" 2>&1
   assert_contains "$list_out" "$package_source"
   local installed_package="$agent_dir/npm/node_modules/pi-yaml-hooks"
@@ -732,7 +744,7 @@ NODE
   local coding_agent_version
   local tui_version
   local node_version
-  pi_version="$($pi_bin --version 2>&1 | sed -n '1p')"
+  pi_version="$(env "${isolated_env[@]}" "$pi_bin" --version 2>&1 | sed -n '1p')"
   node_version="$(node --version)"
   read -r coding_agent_version tui_version < <(node --input-type=module - "$pi_bin" <<'NODE'
 import fs from "node:fs";
@@ -759,8 +771,9 @@ if (!coding.version || !tui?.version) process.exit(1);
 process.stdout.write(`${coding.version} ${tui.version}\n`);
 NODE
 )
-  [[ -n "$pi_version" && "$pi_version" != *unknown* ]] || fail "Pi version is not exact"
-  [[ -n "$coding_agent_version" && -n "$tui_version" ]] || fail "SDK versions are not exact"
+  [[ "$pi_version" == "$PI_TARGET_VERSION" ]] || fail "Pi version mismatch: actual=$pi_version expected=$PI_TARGET_VERSION"
+  [[ "$coding_agent_version" == "$PI_TARGET_VERSION" ]] || fail "coding-agent version mismatch: actual=$coding_agent_version expected=$PI_TARGET_VERSION"
+  [[ "$tui_version" == "$PI_TARGET_VERSION" ]] || fail "pi-tui version mismatch: actual=$tui_version expected=$PI_TARGET_VERSION"
   [[ "$node_version" == v* ]] || fail "Node version is not exact"
 
   local mock_server="$smoke_root/mock-server.mjs"
@@ -801,9 +814,7 @@ EOF
   local rpc_driver="$smoke_root/rpc-driver.mjs"
   write_rpc_driver "$rpc_driver"
   local common_env=(
-    HOME="$isolated_home"
-    USERPROFILE="$isolated_home"
-    PI_CODING_AGENT_DIR="$agent_dir"
+    "${isolated_env[@]}"
     PI_YAML_HOOKS_DEBUG=1
     PI_YAML_HOOKS_ENABLE_USER_BASH=1
     PI_OFFLINE=1
@@ -966,8 +977,36 @@ NODE
   assert_contains "$override_rpc" "Active hooks are valid"
   assert_file "$override_log"
 
+  local no_builtins_start_lines
+  no_builtins_start_lines="$(wc -l < "$events_file")"
+  local no_builtins_rpc="$transcript_dir/no-builtins-rpc.ndjson"
+  local no_builtins_err="$transcript_dir/no-builtins-stderr.txt"
+  env "${common_env[@]}" node "$rpc_driver" "$pi_bin" "$project_dir" "$no_builtins_rpc" "$no_builtins_err" no-builtins "$sessions_dir/no-builtins" "$events_file"
+  assert_contains "$no_builtins_rpc" "hooks-status"
+  assert_contains "$no_builtins_rpc" "hooks-validate"
+  assert_contains "$no_builtins_rpc" "Hooks status for"
+  assert_contains "$no_builtins_rpc" "Active hooks are valid"
+  assert_contains "$no_builtins_rpc" "pi-yaml-hooks-diagnostics"
+  local no_builtins_lifecycle
+  no_builtins_lifecycle="$(node --input-type=module - "$events_file" "$no_builtins_start_lines" <<'NODE'
+import fs from "node:fs";
+
+const [eventsFile, startText] = process.argv.slice(2);
+const rows = fs.readFileSync(eventsFile, "utf8").trim().split("\n").filter(Boolean)
+  .slice(Number(startText)).map((line) => JSON.parse(line));
+const created = rows.filter((row) => row.event === "session.created" && typeof row.session === "string");
+const deleted = rows.filter((row) => row.event === "session.deleted" && typeof row.session === "string");
+const session = created.find(({ session }) => deleted.some((row) => row.session === session))?.session;
+if (!session) throw new Error(`no --no-builtin-tools session has ordered created/deleted lifecycle: ${JSON.stringify(rows)}`);
+const createdIndex = rows.findIndex((row) => row.event === "session.created" && row.session === session);
+const deletedIndex = rows.findIndex((row) => row.event === "session.deleted" && row.session === session);
+if (createdIndex >= deletedIndex) throw new Error(`invalid --no-builtin-tools lifecycle order: created=${createdIndex} deleted=${deletedIndex}`);
+process.stdout.write(`session=${session};created=${createdIndex};deleted=${deletedIndex};graceful-exit=0`);
+NODE
+)"
+
   local combined_host_output="$transcript_dir/combined-host-output.txt"
-  cat "$untrusted_rpc" "$untrusted_err" "$trusted_rpc" "$trusted_err" "$invalid_rpc" "$invalid_err" "$override_rpc" "$override_err" > "$combined_host_output"
+  cat "$untrusted_rpc" "$untrusted_err" "$trusted_rpc" "$trusted_err" "$invalid_rpc" "$invalid_err" "$override_rpc" "$override_err" "$no_builtins_rpc" "$no_builtins_err" > "$combined_host_output"
   assert_not_contains_regex "$combined_host_output" 'Failed to load extension|Error loading extension|Cannot load extension|ERR_MODULE_NOT_FOUND|SyntaxError.*extensions/pi-yaml-hooks'
 
   local pty_driver="$smoke_root/pty-driver.py"
@@ -998,6 +1037,7 @@ NODE
   printf 'A23P PASS — packed artifact installed by native Pi package/settings flow; package=%s@%s sha256=%s source=%s installed=%s\n' "$packed_name" "$packed_version" "$artifact_sha256" "$package_source" "$installed_package"
   pass_count=$((pass_count + 1))
   printf 'A24P PASS — commands, trust, configs, logs, tools, lifecycle, user_bash, prompt, diagnostics, and UI evidence asserted\n'
+  printf 'A24P NO_BUILTINS — native package commands/diagnostics/lifecycle with --no-builtin-tools; %s\n' "$no_builtins_lifecycle"
   printf 'A24P INTERACTIVE %s\n' "$interactive_row"
 
   if [[ -n "$mock_pid" ]] && kill -0 "$mock_pid" >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

Prepare `pi-yaml-hooks` for verified Pi 0.80.10 compatibility without changing shared runtime behavior.

This updates the package release metadata, expands the supported SDK matrix across the Pi 0.80.8 breaking boundary, strengthens version assertions, and adds isolated runtime coverage for Pi with built-in tools disabled.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Infrastructure / CI/CD
- [ ] Performance improvement

## Changes Made

- Bump the package version to `2026.7.18` and update the Pi SDK/TUI development dependencies to `0.80.10`.
- Test exact Pi SDK versions `0.74.0`, `0.79.3`, and `0.80.10`.
- Validate exact versions strictly while supporting npm ranges and tags.
- Add isolated `--no-builtin-tools` runtime coverage for commands, diagnostics, lifecycle events, and graceful exit.
- Keep Pi and OMP optional peer dependencies unchanged.
- Update compatibility and maintenance documentation with the new verification evidence.
- Avoid ModelRuntime, provider-auth, deferred-tool, or shared runtime changes because this extension does not use the affected APIs.

## How to Test

- `npm run typecheck`
- `npm run test:internal`
- `npm run compat:sdk-matrix`
- `bash scripts/smoke/pi-runtime-smoke.sh --automated`
- `npm run compat:host-matrix`

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code for obvious errors
- [x] Added or updated tests where applicable
- [x] Existing tests pass locally
- [x] Updated documentation if needed
- [x] No generated or dependency-directory files are included

## Related Issues

None.

## Screenshots

Not applicable.
