### PR TITLE
Remediate adm-zip audit findings and prepare 2026.7.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.7.18",
+  "version": "2026.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-yaml-hooks",
-      "version": "2026.7.18",
+      "version": "2026.7.19",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.9.0"
@@ -682,7 +682,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3604,13 +3604,13 @@
       ]
     },
     "node_modules/adm-zip": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
-      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-yaml-hooks",
-  "version": "2026.7.18",
+  "version": "2026.7.19",
   "description": "YAML hook automation for the Pi and OMP coding agents: tool guards, session hooks, prompts, notifications, and bash actions.",
   "author": "Kristjan Pikhof <kristjan.pikhof@gmail.com> (https://github.com/KristjanPikhof)",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,9 @@
   "dependencies": {
     "yaml": "^2.9.0"
   },
+  "overrides": {
+    "adm-zip": "0.6.0"
+  },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.10",
     "@earendil-works/pi-tui": "^0.80.10",


### PR DESCRIPTION
<!-- Template: reference/pr-template-bugfix.md -->
## Bug Description

`origin/main` resolves transitive `adm-zip` 0.5.18, which is affected by the high-severity denial-of-service advisory [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85). `npm audit` reports six high-severity findings through the affected dependency chains.

**Expected:**

The release dependency graph should pass `npm audit` without changing the supported package runtime.

**Actual:**

The OMP development dependency graph pulls `adm-zip` through `onnxruntime-node` and `generative-bayesian-network`, and the lockfile resolves the vulnerable 0.5.18 release.

## Root Cause

The transitive dependency ranges allowed `adm-zip` below 0.6.0, and the project did not constrain that indirect package to the patched release.

## Type of Change

- [x] Bug fix

## Fix Description

- Override `adm-zip` to 0.6.0 and update the lockfile resolution and Node engine metadata.
- Advance the package version from 2026.7.18 to 2026.7.19 for the remediated release.
- Normalize the locked `pi-ai` bin path from `dist/cli.js` to `./dist/cli.js`.

## How to Reproduce (Before Fix)

1. Check out `origin/main`.
2. Run `npm ci`.
3. Run `npm audit` and observe the high-severity findings rooted in `adm-zip` below 0.6.0.

## How to Verify (After Fix)

1. Run `npm ci`.
2. Run `npm audit` and confirm it reports `found 0 vulnerabilities`.
3. Run `npm run typecheck`.
4. Run `npm run test:internal`.

## Impact Assessment

- **Severity:** High per the npm advisory; runtime exploitability in this project was not established.
- **Users affected:** Maintainers and contributors installing the OMP development dependency graph.
- **Duration:** Present on `origin/main`; the introducing release was not identified.

## Regression Risk

- The override moves a transitive archive dependency from 0.5.18 to 0.6.0; review OMP development-tool paths that consume ZIP archives.
- The release version and locked CLI bin-path metadata affect package publication and installation, so retain the package/install smoke checks in release validation.

## Checklist

- [x] Root cause identified and documented above
- [x] Fix addresses the root cause (not just symptoms)
- [ ] Added test to prevent regression
- [x] Existing tests pass locally
- [x] Tested the specific reproduction steps
- [ ] No new warnings or console errors introduced

## Related Issues

None found in the branch name or commit messages.
